### PR TITLE
Better yml theme create

### DIFF
--- a/lib/new_theme/create_theme.js
+++ b/lib/new_theme/create_theme.js
@@ -68,7 +68,7 @@ const createSpecsFile = (newThemeDir, newTheme, baseTheme) => {
     layouts: newLayouts,
     key: newTheme
   };
-  const newSpecsStr = yaml.dump(newSpecs, {"lineWidth": -1, "quotingType":'"', "forceQuotes": true});
+  const newSpecsStr = yaml.dump(newSpecs, { lineWidth: -1, quotingType:'"',  forceQuotes: true });
   fs.writeFileSync(path.join(newThemeDir, "specs.yml"), newSpecsStr);
 }
 

--- a/lib/new_theme/create_theme.js
+++ b/lib/new_theme/create_theme.js
@@ -68,7 +68,7 @@ const createSpecsFile = (newThemeDir, newTheme, baseTheme) => {
     layouts: newLayouts,
     key: newTheme
   };
-  const newSpecsStr = yaml.dump(newSpecs);
+  const newSpecsStr = yaml.dump(newSpecs, {"lineWidth": -1,"quotingType":'"',"forceQuotes": true});
   fs.writeFileSync(path.join(newThemeDir, "specs.yml"), newSpecsStr);
 }
 

--- a/lib/new_theme/create_theme.js
+++ b/lib/new_theme/create_theme.js
@@ -68,7 +68,7 @@ const createSpecsFile = (newThemeDir, newTheme, baseTheme) => {
     layouts: newLayouts,
     key: newTheme
   };
-  const newSpecsStr = yaml.dump(newSpecs, {"lineWidth": -1,"quotingType":'"',"forceQuotes": true});
+  const newSpecsStr = yaml.dump(newSpecs, {"lineWidth": -1, "quotingType":'"', "forceQuotes": true});
   fs.writeFileSync(path.join(newThemeDir, "specs.yml"), newSpecsStr);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "event-theme-maker",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "event-theme-maker",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.131.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-theme-maker",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Eventmaker theme developers tools belt",
   "keywords": [],
   "author": "Eventmaker team 🚀",


### PR DESCRIPTION
Fix too many diff if we make comparaison between GC and the new theme
Options used (from [https://github.com/nodeca/js-yaml#dump-object---options-](https://github.com/nodeca/js-yaml#dump-object---options-)):

- lineWidth (remove max length)
- quotingType (use double quote)
- forceQuotes (keep double quote)


Compare before

![Capture d’écran 2022-11-16 à 10 16 50](https://user-images.githubusercontent.com/6553086/202139676-20b824c4-3e85-4f50-893e-fc11c4e188d7.png)

Compare after
![Capture d’écran 2022-11-16 à 10 15 36](https://user-images.githubusercontent.com/6553086/202139718-8f3711e1-bd1c-4097-a6cd-1065e9b91f8b.png)