### PR TITLE
POC add templates replacement assets

### DIFF
--- a/lib/release/pack.js
+++ b/lib/release/pack.js
@@ -71,6 +71,10 @@ const writeAssetsProductionURL = (theme, buildDir, releaseDir, assetsDir) => {
   ["theme", "embed"].forEach(layout => {
     replaceInFile(path.join(releaseDir, "layouts", `${layout}.liquid`), reg, url);
   });
+
+  ["magic_link_signin", "visit_route"].forEach(layout => {
+    replaceInFile(path.join(releaseDir, "templates", `${layout}.liquid`), reg, url);
+  });
 }
 
 const writeSpecsProductionURL = (buildDir, releaseDir) => {


### PR DESCRIPTION
Hi @robinmonjo, in future merge on cms-theme we will use main.css in templates files ex this pr : [https://github.com/applidget/eventmaker-cms-themes/pull/1844/files#diff-6fd365576d9dcc60b5a7bc688e66bf2ca7086ec339d17fe13df74f9b4eb8fb7d](https://github.com/applidget/eventmaker-cms-themes/pull/1844/files#diff-6fd365576d9dcc60b5a7bc688e66bf2ca7086ec339d17fe13df74f9b4eb8fb7d)

How can you handle this ?
This PR is the right way ?

This pr is shitty because we have to duplicate files of templates too :( 