### PR TITLE
Fix DNS issue to favor IPV4

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -2,6 +2,8 @@ const https = require("https");
 const http = require("http");
 const url = require("url");
 const { Readable } = require("stream");
+const dns = require("node:dns");
+dns.setDefaultResultOrder('ipv4first');
 
 module.exports = class {
   constructor(endpoint, token, eventId = null, emailId = null, documentId = null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-theme-maker",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Eventmaker theme developers tools belt",
   "keywords": [],
   "author": "Eventmaker team 🚀",


### PR DESCRIPTION
Since NodeJS 17, `localhost` is resolved into an IPV6 address, instead of IPV4.
So it cannot request Eventmaker web server to fetch data.

This PR fixes it by favoring IPV4 resolution.

https://github.com/nodejs/node/issues/40537#issuecomment-1237194449