### PR TITLE
improve intial sync

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -138,26 +138,15 @@ const performInitialSync = (theme, host, cb) => {
   logInfo("syncing the theme, please be patient...");
   logHelp("use --initialSync=false to avoid initial theme syncing");
 
-  let type, typeId;
-
-  if (emailId) {
-    type = "email";
-    typeId = emailId;
-  } else if (documentId) {
-    type = "document";
-    typeId = documentId;
-  } else {
-    type = "website";
-  }
-
-  apiClient.themeFullSync(host, type, typeId, (ok, error) => {
-    if (ok) {
-      return cb();
-    }
-
+  const handleSyncResponse = (themeType) => (ok, error) => {
+    if (ok) return cb();
     wrapRed(() => log(stringify(error)));
-    logFatal("error reloading theme");
-  });
+    logFatal(`error reloading ${themeType} theme`);
+  };
+
+  apiClient.themeFullSync(host, "website", null, handleSyncResponse("website"));
+  if (emailId) apiClient.themeFullSync(host, "email", emailId, handleSyncResponse("email"));
+  if (documentId) apiClient.themeFullSync(host, "document", documentId, handleSyncResponse("document"));
 }
 
 const startAutoSync = (theme, host) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "event-theme-maker",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-theme-maker",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.131.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-theme-maker",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Eventmaker theme developers tools belt",
   "keywords": [],
   "author": "Eventmaker team 🚀",


### PR DESCRIPTION
Always sync website and allow to sync email and document at the same time

I am using etm-local-config with eventId and emailId provided and reloading the website during startup wasn't possible