### PR TITLE
More detailed errors for fetching token

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -20,7 +20,7 @@ module.exports = class {
       if (status === 200) {
         return cb(true, response.credentials);
       }
-      cb(false, response.error);
+      cb(false, response);
     });
   }
 
@@ -30,7 +30,7 @@ module.exports = class {
       if (status === 200) {
         return cb(true, response.token);
       }
-      cb(false, response.error);
+      cb(false, response);
     });
   }
 


### PR DESCRIPTION
Before
<img width="1289" alt="Capture d’écran 2024-10-10 à 16 48 37" src="https://github.com/user-attachments/assets/d1abb434-748b-4563-ab60-9db9b59bcf2b">

After
<img width="1289" alt="Capture d’écran 2024-10-10 à 16 49 58" src="https://github.com/user-attachments/assets/60ff6737-e209-4c01-a7e9-c37d62a21032">


The chain issue is due to our Lovely Netskope filtering, it can be bypassed with a local copy of event-theme-maker..
and this changes..
<img width="475" alt="Capture d’écran 2024-10-10 à 16 53 44" src="https://github.com/user-attachments/assets/a7d18536-6ec7-4023-8f9f-05e5365a0a35">

I don't know what we have to do in the IPD side but these explanations are more futur proof, it explain detailed issues
